### PR TITLE
Bump rustls to 0.23.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,10 @@ appveyor = { repository = "async-std/async-tls" }
 [dependencies]
 futures-io = "0.3.5"
 futures-core = "0.3.5"
-rustls = "0.21"
+rustls = "0.23.29"
 rustls-pemfile = "1.0"
-# webpki = { version = "0.22.0", optional = true }
-rustls-webpki = { version = "0.101.4", optional = true }
-webpki-roots = { version = "0.22.3", optional = true }
+rustls-webpki = { version = "0.103.4", optional = true }
+webpki-roots = { version = "1.0.1", optional = true }
 
 [features]
 default = ["client", "server"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ appveyor = { repository = "async-std/async-tls" }
 futures-io = "0.3.5"
 futures-core = "0.3.5"
 rustls = "0.23.29"
-rustls-pemfile = "1.0"
 rustls-webpki = { version = "0.103.4", optional = true }
 webpki-roots = { version = "1.0.1", optional = true }
 

--- a/examples/client/Cargo.toml
+++ b/examples/client/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 structopt = "0.3.9"
-rustls = "0.20.6"
-rustls-pemfile = "1.0"
+rustls = "0.23.29"
 async-std = "1.11.0"
 async-tls = { path = "../.." }

--- a/examples/client/src/main.rs
+++ b/examples/client/src/main.rs
@@ -4,10 +4,10 @@ use async_std::prelude::*;
 use async_std::task;
 use async_tls::TlsConnector;
 
+use rustls::pki_types::pem::{self, PemObject as _};
+use rustls::pki_types::CertificateDer;
 use rustls::ClientConfig;
-use rustls_pemfile::certs;
 
-use std::io::{BufReader, Cursor};
 use std::net::ToSocketAddrs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -55,7 +55,9 @@ fn main() -> io::Result<()> {
         // Create default connector comes preconfigured with all you need to safely connect
         // to remote servers!
         let connector = if let Some(cafile) = cafile {
-            connector_for_ca_file(cafile).await?
+            connector_for_ca_file(cafile)
+                .await
+                .expect("should not fail to load certificate")
         } else {
             TlsConnector::default()
         };
@@ -81,14 +83,12 @@ fn main() -> io::Result<()> {
     })
 }
 
-async fn connector_for_ca_file(cafile: &Path) -> io::Result<TlsConnector> {
+async fn connector_for_ca_file(cafile: &Path) -> Result<TlsConnector, pem::Error> {
     let mut root_store = rustls::RootCertStore::empty();
-    let ca_bytes = async_std::fs::read(cafile).await?;
-    let cert = certs(&mut BufReader::new(Cursor::new(ca_bytes))).unwrap();
-    debug_assert_eq!((1, 0), root_store.add_parsable_certificates(&cert));
+    let certs = CertificateDer::pem_file_iter(cafile)?.collect::<Result<Vec<_>, _>>()?;
+    debug_assert_eq!((1, 0), root_store.add_parsable_certificates(certs));
 
     let config = ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     Ok(TlsConnector::from(Arc::new(config)))

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -8,6 +8,5 @@ edition = "2018"
 async-std = "1.11.0"
 async-tls = { path = "../.." }
 futures-lite = "1.12.0"
-rustls = "0.20.6"
-rustls-pemfile = "1.0"
+rustls = "0.23.29"
 structopt = "0.3.9"

--- a/examples/server/src/main.rs
+++ b/examples/server/src/main.rs
@@ -4,11 +4,10 @@ use async_std::stream::StreamExt;
 use async_std::task;
 use async_tls::TlsAcceptor;
 use futures_lite::io::AsyncWriteExt;
-use rustls::{Certificate, PrivateKey, ServerConfig};
-use rustls_pemfile::{certs, read_one, Item};
+use rustls::pki_types::pem::{self, PemObject as _};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::ServerConfig;
 
-use std::fs::File;
-use std::io::BufReader;
 use std::net::ToSocketAddrs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -28,42 +27,33 @@ struct Options {
 }
 
 /// Load the passed certificates file
-fn load_certs(path: &Path) -> io::Result<Vec<Certificate>> {
-    Ok(certs(&mut BufReader::new(File::open(path)?))
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid cert"))?
-        .into_iter()
-        .map(Certificate)
-        .collect())
+fn load_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>, pem::Error> {
+    CertificateDer::pem_file_iter(path)?.collect::<Result<Vec<_>, _>>()
 }
 
 /// Load the passed keys file
-fn load_key(path: &Path) -> io::Result<PrivateKey> {
-    match read_one(&mut BufReader::new(File::open(path)?)) {
-        Ok(Some(Item::RSAKey(data) | Item::PKCS8Key(data))) => Ok(PrivateKey(data)),
-        Ok(_) => Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("invalid key in {}", path.display()),
-        )),
-        Err(e) => Err(io::Error::new(io::ErrorKind::InvalidInput, e)),
-    }
+fn load_key(path: &Path) -> Result<PrivateKeyDer<'static>, pem::Error> {
+    PrivateKeyDer::pem_file_iter(path)?
+        .collect::<Result<Vec<_>, _>>()?
+        .pop()
+        .ok_or(pem::Error::NoItemsFound)
 }
 
 /// Configure the server using rusttls
 /// See https://docs.rs/rustls/0.16.0/rustls/struct.ServerConfig.html for details
 ///
 /// A TLS server needs a certificate and a fitting private key
-fn load_config(options: &Options) -> io::Result<ServerConfig> {
+fn load_config(options: &Options) -> Result<ServerConfig, pem::Error> {
     let certs = load_certs(&options.cert)?;
     debug_assert_eq!(1, certs.len());
     let key = load_key(&options.key)?;
 
     // we don't use client authentication
     let config = ServerConfig::builder()
-        .with_safe_defaults()
         .with_no_client_auth()
         // set this server to use one cert together with the loaded private key
         .with_single_cert(certs, key)
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+        .map_err(|err| pem::Error::Io(io::Error::new(io::ErrorKind::InvalidInput, err)))?;
 
     Ok(config)
 }
@@ -104,7 +94,7 @@ fn main() -> io::Result<()> {
         .next()
         .ok_or_else(|| io::Error::from(io::ErrorKind::AddrNotAvailable))?;
 
-    let config = load_config(&options)?;
+    let config = load_config(&options).expect("should not fail to load config");
 
     // We create one TLSAcceptor around a shared configuration.
     // Cloning the acceptor will not clone the configuration.

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -3,7 +3,8 @@ use crate::common::tls_state::TlsState;
 use crate::client;
 
 use futures_io::{AsyncRead, AsyncWrite};
-use rustls::{ClientConfig, ClientConnection, OwnedTrustAnchor, RootCertStore, ServerName};
+use rustls::{ClientConfig, ClientConnection};
+use rustls::pki_types::ServerName;
 use std::convert::TryFrom;
 use std::future::Future;
 use std::io;
@@ -64,19 +65,13 @@ impl From<ClientConfig> for TlsConnector {
 
 impl Default for TlsConnector {
     fn default() -> Self {
-        let mut root_certs = RootCertStore::empty();
-        root_certs.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
-            OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-            )
-        }));
+        let root_certs = rustls::RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+        };
         let config = ClientConfig::builder()
-            .with_safe_defaults()
             .with_root_certificates(root_certs)
             .with_no_client_auth();
-        Arc::new(config).into()
+        TlsConnector::from(config)
     }
 }
 
@@ -118,7 +113,7 @@ impl TlsConnector {
         F: FnOnce(&mut ClientConnection),
     {
         let domain = match ServerName::try_from(domain.as_ref()) {
-            Ok(domain) => domain,
+            Ok(domain) => domain.to_owned(),
             Err(_) => {
                 return Connect(ConnectInner::Error(Some(io::Error::new(
                     io::ErrorKind::InvalidInput,

--- a/src/rusttls/test_stream.rs
+++ b/src/rusttls/test_stream.rs
@@ -4,11 +4,11 @@ use futures_io::{AsyncRead, AsyncWrite};
 use futures_util::io::{AsyncReadExt, AsyncWriteExt};
 use futures_util::task::{noop_waker_ref, Context};
 use futures_util::{future, ready};
+use rustls::pki_types::pem::PemObject as _;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
 use rustls::{
-    Certificate, ClientConfig, ClientConnection, ConnectionCommon, PrivateKey, RootCertStore,
-    ServerConfig, ServerConnection, ServerName,
+    ClientConfig, ClientConnection, ConnectionCommon, RootCertStore, ServerConfig, ServerConnection,
 };
-use rustls_pemfile::{certs, pkcs8_private_keys};
 use std::convert::TryFrom;
 use std::io::{self, BufReader, Cursor, Read, Write};
 use std::pin::Pin;
@@ -223,12 +223,14 @@ fn make_pair() -> (ServerConnection, ClientConnection) {
     const CHAIN: &str = include_str!("../../tests/end.chain");
     const RSA: &str = include_str!("../../tests/end.rsa");
 
-    let cert = certs(&mut BufReader::new(Cursor::new(CERT))).unwrap();
-    let cert = cert.into_iter().map(Certificate).collect();
-    let mut keys = pkcs8_private_keys(&mut BufReader::new(Cursor::new(RSA))).unwrap();
-    let key = PrivateKey(keys.pop().unwrap());
+    let cert = CertificateDer::pem_reader_iter(&mut BufReader::new(Cursor::new(CERT)))
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+    let mut keys = PrivatePkcs8KeyDer::pem_reader_iter(&mut BufReader::new(Cursor::new(RSA)))
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+    let key = PrivateKeyDer::Pkcs8(keys.pop().unwrap());
     let sconfig = ServerConfig::builder()
-        .with_safe_defaults()
         .with_no_client_auth()
         .with_single_cert(cert, key)
         .unwrap();
@@ -236,11 +238,12 @@ fn make_pair() -> (ServerConnection, ClientConnection) {
 
     let domain = ServerName::try_from("localhost").unwrap();
     let mut root_store = RootCertStore::empty();
-    let chain = certs(&mut BufReader::new(Cursor::new(CHAIN))).unwrap();
-    let (added, ignored) = root_store.add_parsable_certificates(&chain);
+    let chain = CertificateDer::pem_reader_iter(&mut BufReader::new(Cursor::new(CHAIN)))
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+    let (added, ignored) = root_store.add_parsable_certificates(chain);
     assert!(added >= 1 && ignored == 0);
     let cconfig = ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     let client = ClientConnection::new(Arc::new(cconfig), domain);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,8 +5,9 @@ use async_std::prelude::*;
 use async_std::task;
 use async_tls::{TlsAcceptor, TlsConnector};
 use lazy_static::lazy_static;
-use rustls::{Certificate, ClientConfig, PrivateKey, RootCertStore, ServerConfig};
-use rustls_pemfile::{certs, pkcs8_private_keys};
+use rustls::pki_types::pem::PemObject as _;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use rustls::{ClientConfig, RootCertStore, ServerConfig};
 use std::io::{BufReader, Cursor};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -15,49 +16,59 @@ const CERT: &str = include_str!("end.cert");
 const CHAIN: &str = include_str!("end.chain");
 const RSA: &str = include_str!("end.rsa");
 
+type TestServer = (SocketAddr, &'static str, Vec<CertificateDer<'static>>);
+
 lazy_static! {
-    static ref TEST_SERVER: (SocketAddr, &'static str, Vec<Vec<u8>>) = {
-        let cert = certs(&mut BufReader::new(Cursor::new(CERT))).unwrap();
-        let cert = cert.into_iter().map(Certificate).collect();
-        let chain = certs(&mut BufReader::new(Cursor::new(CHAIN))).unwrap();
-        let mut keys = pkcs8_private_keys(&mut BufReader::new(Cursor::new(RSA))).unwrap();
-        let key = PrivateKey(keys.pop().unwrap());
-        let sconfig = ServerConfig::builder()
-            .with_safe_defaults()
-            .with_no_client_auth()
-            .with_single_cert(cert, key)
-            .unwrap();
-        let acceptor = TlsAcceptor::from(Arc::new(sconfig));
-
-        let (send, recv) = bounded(1);
-
-        task::spawn(async move {
-            let addr = SocketAddr::from(([127, 0, 0, 1], 0));
-            let listener = TcpListener::bind(&addr).await?;
-
-            send.send(listener.local_addr()?).await.unwrap();
-
-            let mut incoming = listener.incoming();
-            while let Some(stream) = incoming.next().await {
-                let acceptor = acceptor.clone();
-                task::spawn(async move {
-                    use futures_util::io::AsyncReadExt;
-                    let stream = acceptor.accept(stream?).await?;
-                    let (mut reader, mut writer) = stream.split();
-                    io::copy(&mut reader, &mut writer).await?;
-                    Ok(()) as io::Result<()>
-                });
-            }
-
-            Ok(()) as io::Result<()>
-        });
-
-        let addr = task::block_on(async move { recv.recv().await.unwrap() });
-        (addr, "localhost", chain)
+    static ref TEST_SERVER: TestServer = {
+        build_test_server()
     };
 }
 
-fn start_server() -> &'static (SocketAddr, &'static str, Vec<Vec<u8>>) {
+fn build_test_server() -> TestServer {
+    let cert = CertificateDer::pem_reader_iter(&mut BufReader::new(Cursor::new(CERT)))
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+    let chain = CertificateDer::pem_reader_iter(&mut BufReader::new(Cursor::new(CHAIN)))
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+    let mut keys = PrivatePkcs8KeyDer::pem_reader_iter(&mut BufReader::new(Cursor::new(RSA)))
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+    let key = PrivateKeyDer::Pkcs8(keys.pop().unwrap());
+    let sconfig = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(cert, key)
+        .unwrap();
+    let acceptor = TlsAcceptor::from(Arc::new(sconfig));
+
+    let (send, recv) = bounded(1);
+
+    task::spawn(async move {
+        let addr = SocketAddr::from(([127, 0, 0, 1], 0));
+        let listener = TcpListener::bind(&addr).await?;
+
+        send.send(listener.local_addr()?).await.unwrap();
+
+        let mut incoming = listener.incoming();
+        while let Some(stream) = incoming.next().await {
+            let acceptor = acceptor.clone();
+            task::spawn(async move {
+                use futures_util::io::AsyncReadExt;
+                let stream = acceptor.accept(stream?).await?;
+                let (mut reader, mut writer) = stream.split();
+                io::copy(&mut reader, &mut writer).await?;
+                Ok(()) as io::Result<()>
+            });
+        }
+
+        Ok(()) as io::Result<()>
+    });
+
+    let addr = task::block_on(async move { recv.recv().await.unwrap() });
+    (addr, "localhost", chain)
+}
+
+fn start_server() -> &'static TestServer {
     &*TEST_SERVER
 }
 
@@ -82,10 +93,10 @@ async fn start_client(addr: SocketAddr, domain: &str, config: Arc<ClientConfig>)
 fn pass() {
     let (addr, domain, chain) = start_server();
     let mut root_store = RootCertStore::empty();
-    let (added, ignored) = root_store.add_parsable_certificates(&chain);
+    let (added, ignored) =
+        root_store.add_parsable_certificates(chain.clone());
     assert!(added >= 1 && ignored == 0);
     let config = ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     task::block_on(start_client(*addr, domain, Arc::new(config))).unwrap();
@@ -95,10 +106,10 @@ fn pass() {
 fn fail() {
     let (addr, domain, chain) = start_server();
     let mut root_store = RootCertStore::empty();
-    let (added, ignored) = root_store.add_parsable_certificates(&chain);
+    let (added, ignored) =
+        root_store.add_parsable_certificates(chain.clone());
     assert!(added >= 1 && ignored == 0);
     let config = ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     let config = Arc::new(config);


### PR DESCRIPTION
## Description

This will allow us to eliminate our rustls 0.21 dependency from `warp-internal`.

## Testing

- [x] Ran `cargo test` in this crate and verified that all tests pass.
- [x] Modified https://github.com/warpdotdev/warp-internal/pull/16489 to patch `async-tls` to use this branch and verified that RTC (which is what ultimately pulls in this crate) still works correctly.