### PR TITLE
fix: update rustls-webpki to resolve GHSA-82j2-j2ch-gfr8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,11 @@ appveyor = { repository = "async-std/async-tls" }
 [dependencies]
 futures-io = "0.3.5"
 futures-core = "0.3.5"
-rustls = "0.21"
-rustls-pemfile = "1.0"
+rustls = "0.23"
+rustls-pemfile = "2.2"
 # webpki = { version = "0.22.0", optional = true }
-rustls-webpki = { version = "0.101.4", optional = true }
-webpki-roots = { version = "0.22.3", optional = true }
+rustls-webpki = { version = "0.103.13", optional = true }
+webpki-roots = { version = "1.0", optional = true }
 
 [features]
 default = ["client", "server"]

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -3,7 +3,8 @@ use crate::common::tls_state::TlsState;
 use crate::client;
 
 use futures_io::{AsyncRead, AsyncWrite};
-use rustls::{ClientConfig, ClientConnection, OwnedTrustAnchor, RootCertStore, ServerName};
+use rustls::pki_types::ServerName;
+use rustls::{ClientConfig, ClientConnection, RootCertStore};
 use std::convert::TryFrom;
 use std::future::Future;
 use std::io;
@@ -65,15 +66,8 @@ impl From<ClientConfig> for TlsConnector {
 impl Default for TlsConnector {
     fn default() -> Self {
         let mut root_certs = RootCertStore::empty();
-        root_certs.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
-            OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-            )
-        }));
+        root_certs.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
         let config = ClientConfig::builder()
-            .with_safe_defaults()
             .with_root_certificates(root_certs)
             .with_no_client_auth();
         Arc::new(config).into()
@@ -117,7 +111,7 @@ impl TlsConnector {
         IO: AsyncRead + AsyncWrite + Unpin,
         F: FnOnce(&mut ClientConnection),
     {
-        let domain = match ServerName::try_from(domain.as_ref()) {
+        let domain = match ServerName::try_from(domain.as_ref().to_owned()) {
             Ok(domain) => domain,
             Err(_) => {
                 return Connect(ConnectInner::Error(Some(io::Error::new(

--- a/src/rusttls/stream.rs
+++ b/src/rusttls/stream.rs
@@ -48,14 +48,14 @@ impl Conn<'_> {
         }
     }
 
-    pub(crate) fn reader(&mut self) -> Reader {
+    pub(crate) fn reader(&mut self) -> Reader<'_> {
         match self {
             Conn::Client(c) => c.reader(),
             Conn::Server(c) => c.reader(),
         }
     }
 
-    pub(crate) fn writer(&mut self) -> Writer {
+    pub(crate) fn writer(&mut self) -> Writer<'_> {
         match self {
             Conn::Client(c) => c.writer(),
             Conn::Server(c) => c.writer(),

--- a/src/rusttls/test_stream.rs
+++ b/src/rusttls/test_stream.rs
@@ -4,9 +4,9 @@ use futures_io::{AsyncRead, AsyncWrite};
 use futures_util::io::{AsyncReadExt, AsyncWriteExt};
 use futures_util::task::{noop_waker_ref, Context};
 use futures_util::{future, ready};
+use rustls::pki_types::{PrivateKeyDer, ServerName};
 use rustls::{
-    Certificate, ClientConfig, ClientConnection, ConnectionCommon, PrivateKey, RootCertStore,
-    ServerConfig, ServerConnection, ServerName,
+    ClientConfig, ClientConnection, ConnectionCommon, RootCertStore, ServerConfig, ServerConnection,
 };
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use std::convert::TryFrom;
@@ -223,12 +223,15 @@ fn make_pair() -> (ServerConnection, ClientConnection) {
     const CHAIN: &str = include_str!("../../tests/end.chain");
     const RSA: &str = include_str!("../../tests/end.rsa");
 
-    let cert = certs(&mut BufReader::new(Cursor::new(CERT))).unwrap();
-    let cert = cert.into_iter().map(Certificate).collect();
-    let mut keys = pkcs8_private_keys(&mut BufReader::new(Cursor::new(RSA))).unwrap();
-    let key = PrivateKey(keys.pop().unwrap());
+    let cert = certs(&mut BufReader::new(Cursor::new(CERT)))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    let key: PrivateKeyDer<'static> = pkcs8_private_keys(&mut BufReader::new(Cursor::new(RSA)))
+        .next()
+        .unwrap()
+        .unwrap()
+        .into();
     let sconfig = ServerConfig::builder()
-        .with_safe_defaults()
         .with_no_client_auth()
         .with_single_cert(cert, key)
         .unwrap();
@@ -236,11 +239,12 @@ fn make_pair() -> (ServerConnection, ClientConnection) {
 
     let domain = ServerName::try_from("localhost").unwrap();
     let mut root_store = RootCertStore::empty();
-    let chain = certs(&mut BufReader::new(Cursor::new(CHAIN))).unwrap();
-    let (added, ignored) = root_store.add_parsable_certificates(&chain);
+    let chain = certs(&mut BufReader::new(Cursor::new(CHAIN)))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    let (added, ignored) = root_store.add_parsable_certificates(chain);
     assert!(added >= 1 && ignored == 0);
     let cconfig = ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     let client = ClientConnection::new(Arc::new(cconfig), domain);

--- a/src/test_0rtt.rs
+++ b/src/test_0rtt.rs
@@ -3,7 +3,7 @@ use async_std::net::TcpStream;
 use async_std::sync::Arc;
 use futures_executor::block_on;
 use futures_util::io::{AsyncReadExt, AsyncWriteExt};
-use rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore};
+use rustls::{ClientConfig, RootCertStore};
 use std::io;
 use std::net::ToSocketAddrs;
 
@@ -29,15 +29,8 @@ async fn get(
 #[test]
 fn test_0rtt() {
     let mut root_certs = RootCertStore::empty();
-    root_certs.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
-        OwnedTrustAnchor::from_subject_spki_name_constraints(
-            ta.subject,
-            ta.spki,
-            ta.name_constraints,
-        )
-    }));
+    root_certs.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     let mut config = ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_certs)
         .with_no_client_auth();
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,8 @@ use async_std::prelude::*;
 use async_std::task;
 use async_tls::{TlsAcceptor, TlsConnector};
 use lazy_static::lazy_static;
-use rustls::{Certificate, ClientConfig, PrivateKey, RootCertStore, ServerConfig};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::{ClientConfig, RootCertStore, ServerConfig};
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use std::io::{BufReader, Cursor};
 use std::net::SocketAddr;
@@ -16,14 +17,19 @@ const CHAIN: &str = include_str!("end.chain");
 const RSA: &str = include_str!("end.rsa");
 
 lazy_static! {
-    static ref TEST_SERVER: (SocketAddr, &'static str, Vec<Vec<u8>>) = {
-        let cert = certs(&mut BufReader::new(Cursor::new(CERT))).unwrap();
-        let cert = cert.into_iter().map(Certificate).collect();
-        let chain = certs(&mut BufReader::new(Cursor::new(CHAIN))).unwrap();
-        let mut keys = pkcs8_private_keys(&mut BufReader::new(Cursor::new(RSA))).unwrap();
-        let key = PrivateKey(keys.pop().unwrap());
+    static ref TEST_SERVER: (SocketAddr, &'static str, Vec<CertificateDer<'static>>) = {
+        let cert = certs(&mut BufReader::new(Cursor::new(CERT)))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let chain = certs(&mut BufReader::new(Cursor::new(CHAIN)))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let key: PrivateKeyDer<'static> = pkcs8_private_keys(&mut BufReader::new(Cursor::new(RSA)))
+            .next()
+            .unwrap()
+            .unwrap()
+            .into();
         let sconfig = ServerConfig::builder()
-            .with_safe_defaults()
             .with_no_client_auth()
             .with_single_cert(cert, key)
             .unwrap();
@@ -57,7 +63,7 @@ lazy_static! {
     };
 }
 
-fn start_server() -> &'static (SocketAddr, &'static str, Vec<Vec<u8>>) {
+fn start_server() -> &'static (SocketAddr, &'static str, Vec<CertificateDer<'static>>) {
     &*TEST_SERVER
 }
 
@@ -82,10 +88,9 @@ async fn start_client(addr: SocketAddr, domain: &str, config: Arc<ClientConfig>)
 fn pass() {
     let (addr, domain, chain) = start_server();
     let mut root_store = RootCertStore::empty();
-    let (added, ignored) = root_store.add_parsable_certificates(&chain);
+    let (added, ignored) = root_store.add_parsable_certificates(chain.clone());
     assert!(added >= 1 && ignored == 0);
     let config = ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     task::block_on(start_client(*addr, domain, Arc::new(config))).unwrap();
@@ -95,10 +100,9 @@ fn pass() {
 fn fail() {
     let (addr, domain, chain) = start_server();
     let mut root_store = RootCertStore::empty();
-    let (added, ignored) = root_store.add_parsable_certificates(&chain);
+    let (added, ignored) = root_store.add_parsable_certificates(chain.clone());
     assert!(added >= 1 && ignored == 0);
     let config = ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     let config = Arc::new(config);


### PR DESCRIPTION
## Summary
- Updates the Rustls dependency stack so `rustls-webpki` resolves to patched `0.103.13`.
- Migrates certificate, key, root store, and server-name usage to Rustls 0.23 APIs.
- Covers Dependabot alerts:
  - https://github.com/warpdotdev/async-tls/security/dependabot/1
  - https://github.com/warpdotdev/async-tls/security/dependabot/2
  - https://github.com/warpdotdev/async-tls/security/dependabot/3

## Vulnerabilities
- GHSA-82j2-j2ch-gfr8 / RUSTSEC-2026-0104: rustls-webpki denial of service via panic on malformed CRL BIT STRING
  - Advisory: https://github.com/rustls/webpki/security/advisories/GHSA-82j2-j2ch-gfr8
  - Severity: high
  - Patched version: 0.103.13
- GHSA-965h-392x-2mh5 / RUSTSEC-2026-0098: webpki URI name constraints incorrectly accepted
  - Advisory: https://github.com/rustls/webpki/security/advisories/GHSA-965h-392x-2mh5
  - Severity: low
  - Patched version: 0.103.12
- GHSA-xgp8-3hg3-c2mh / RUSTSEC-2026-0099: webpki wildcard name constraints incorrectly accepted
  - Advisory: https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh
  - Severity: low
  - Patched version: 0.103.12

## Changes
- `rustls`: `0.21` -> `0.23`
- `rustls-pemfile`: `1.0` -> `2.2`
- `rustls-webpki`: `0.101.4` -> `0.103.13`
- `webpki-roots`: `0.22.3` -> `1.0`
- Updated direct and transitive Rustls usage so `cargo tree --all-features -i rustls-webpki` resolves only `rustls-webpki v0.103.13`.

## Verification
- `cargo fmt --check`
- `cargo build --all-features`
- `cargo test --all-features`
- `cargo audit` (no `rustls-webpki` vulnerability reported; existing allowed warnings remain for `async-std` and `rustls-pemfile` unmaintained advisories)

_Conversation: https://staging.warp.dev/conversation/4c886604-4fe8-423f-b872-ee47b09f53d0_
_Run: https://oz.staging.warp.dev/runs/019e3184-23a2-70e5-b795-0116e7119a7f_
_This PR was generated with [Oz](https://warp.dev/oz)._
